### PR TITLE
Defer exception raising until the moment that llc needed.

### DIFF
--- a/bin/rubyc
+++ b/bin/rubyc
@@ -47,7 +47,7 @@ class Compiler
     path = File.join(RbConfig::CONFIG['bindir'], progname)
     unless File.exist?(path)
       if must_be_in_bindir
-        raise "Can't locate program `#{progname}' in #{Config::CONFIG['bindir']}"
+        return nil
       end
       path = `which #{progname}`.strip
       raise "Can't locate program `#{progname}'" if path.empty?
@@ -62,7 +62,7 @@ class Compiler
   LIPO = locate('lipo')
   STRIP = locate('strip')
   MACRUBY = locate('macruby')
-  MACRUBY_LLC = locate('llc', true)
+  MACRUBY_LLC = locate('llc', true) 
   LLC = File.join(RbConfig::CONFIG['LLVM_PATH'], 'bin/llc')
 
   def initialize(opts)
@@ -102,6 +102,8 @@ class Compiler
       @llc = MACRUBY_LLC
       @macruby = MACRUBY
     end
+    
+    raise "Can't locate program `llc' in #{Config::CONFIG['bindir']}" unless @llc
 
     @llc_flags = '-relocation-model=pic -disable-fp-elim '
     if system("#{@llc} -help | grep jit-enable-eh >& /dev/null")


### PR DESCRIPTION
During the initial compilation and installation step, there will be no llc located in bindir.
It's also unnecessary for there to be, as rubyc is called with the --internal flag.

Allows execution of `rubyc` in cases where bindir/llc does not exist provided the --internal
flag is passed.

NOTE: This may not be the best way to accomplish this, but it's all I could think of based
on the organization of the code as it stands.
