### PR TITLE
fix a memory leak when parsing json fails

### DIFF
--- a/ext/json/rubyext.c
+++ b/ext/json/rubyext.c
@@ -236,8 +236,9 @@ json_parse_chunk(const unsigned char* chunk, unsigned int len, yajl_handle parse
     
     if (status != yajl_status_ok && status != yajl_status_insufficient_data) {
         unsigned char* str = yajl_get_error(parser, 1, chunk, len);
-        rb_raise(rb_cParseError, "%s", (const char*) str);
+        VALUE errobj = rb_exc_new2(cParseError, (const char*) str);
         yajl_free_error(parser, str);
+        rb_exc_raise(errobj);
     }
 }
 


### PR DESCRIPTION
I had a fix for this in place upstream in yajl-ruby, just noticed it was still in the sources in here. This of course assumes rb_raise works like it does in MRI/YARV (short circuiting the function before yajl_free_error could have been called)
