### PR TITLE
Make Exception a subclass of NSException (wip)

### DIFF
--- a/compiler.cpp
+++ b/compiler.cpp
@@ -6873,9 +6873,6 @@ RoxorCompiler::compile_objc_stub(Function *ruby_func, IMP ruby_imp,
     }
 
 #if !__LP64__
-    // TODO so should we just use the body of rb_rb2oc_exc_handler here directly?
-    // Because we no longer need to convert the exception, just throw it.
-
     // The 32-bit Objective-C runtime doesn't use C++ exceptions, therefore
     // we must convert Ruby exceptions to Objective-C ones.
     bb = rescue_invoke_bb;

--- a/compiler.cpp
+++ b/compiler.cpp
@@ -6873,6 +6873,9 @@ RoxorCompiler::compile_objc_stub(Function *ruby_func, IMP ruby_imp,
     }
 
 #if !__LP64__
+    // TODO so should we just use the body of rb_rb2oc_exc_handler here directly?
+    // Because we no longer need to convert the exception, just throw it.
+
     // The 32-bit Objective-C runtime doesn't use C++ exceptions, therefore
     // we must convert Ruby exceptions to Objective-C ones.
     bb = rescue_invoke_bb;

--- a/dispatcher.cpp
+++ b/dispatcher.cpp
@@ -480,12 +480,13 @@ __rb_vm_objc_dispatch(rb_vm_objc_stub_t *stub, IMP imp, id rcv, SEL sel,
 	return (*stub)(imp, rcv, sel, argc, argv);
     }
     @catch (id exc) {
+	rb_ivar_set((VALUE)exc, rb_intern("bt"), rb_vm_backtrace(0));
+#if __LP64__
 	if (rb_vm_current_exception() == Qnil) {
-            rb_ivar_set((VALUE)exc, rb_intern("bt"), rb_vm_backtrace(0));
 	    rb_vm_set_current_exception((VALUE)exc);
 	    throw;
 	}
-	// TODO what exactly did this do? i.e. how did it reach this path?
+#endif
 	rb_exc_raise((VALUE)exc);
 	throw;
     }

--- a/dispatcher.cpp
+++ b/dispatcher.cpp
@@ -480,17 +480,13 @@ __rb_vm_objc_dispatch(rb_vm_objc_stub_t *stub, IMP imp, id rcv, SEL sel,
 	return (*stub)(imp, rcv, sel, argc, argv);
     }
     @catch (id exc) {
-	bool created = false;
-	VALUE rbexc = rb_oc2rb_exception(exc, &created);
-#if __LP64__
 	if (rb_vm_current_exception() == Qnil) {
-	    rb_vm_set_current_exception(rbexc);
+            rb_ivar_set((VALUE)exc, rb_intern("bt"), rb_vm_backtrace(0));
+	    rb_vm_set_current_exception((VALUE)exc);
 	    throw;
 	}
-#endif
-	if (created) {
-	    rb_exc_raise(rbexc);
-	}
+	// TODO what exactly did this do? i.e. how did it reach this path?
+	rb_exc_raise((VALUE)exc);
 	throw;
     }
     abort(); // never reached

--- a/error.c
+++ b/error.c
@@ -716,7 +716,15 @@ name_err_initialize(VALUE self, SEL sel, int argc, VALUE *argv)
 static VALUE
 name_err_name(VALUE self, SEL sel)
 {
-    return rb_attr_get(self, rb_intern("name"));
+    VALUE name = rb_attr_get(self, rb_intern("name"));
+    // 1. Ensure that we always return a string, because this might be called
+    //    by Objective-C code that expects it to return the exception name.
+    // 2. When there is a name, prepend it with an explanation that this is in
+    //    fact a NameError. Otherwise Objective-C code that expects the
+    //    exception name might result in a name being printed that doesn't make
+    //    sense.
+    return name == Qnil ? rb_str_new2("NameError") :
+	rb_sprintf("NameError for name: %s", RSTRING_PTR(name));
 }
 
 /*

--- a/objc.h
+++ b/objc.h
@@ -75,9 +75,6 @@ rb_objc_is_kind_of(id object, Class klass)
     return false;
 }
 
-id rb_rb2oc_exception(VALUE exc);
-VALUE rb_oc2rb_exception(id exc, bool *created);
-
 size_t rb_objc_type_size(const char *type);
 
 static inline int

--- a/objc.m
+++ b/objc.m
@@ -506,7 +506,8 @@ rb_obj_imp_isaForAutonotifying(void *rcv, SEL sel)
 
 - (NSArray *)backtrace
 {
-  return (NSArray *)rb_attr_get((VALUE)self, rb_intern("bt"));
+  VALUE rb_bt = rb_attr_get((VALUE)self, rb_intern("bt"));
+  return rb_bt == Qnil ? [self callStackSymbols] : (NSArray *)rb_bt;
 }
 
 @end

--- a/objc.m
+++ b/objc.m
@@ -497,39 +497,19 @@ rb_obj_imp_isaForAutonotifying(void *rcv, SEL sel)
     return ret;
 }
 
-id
-rb_rb2oc_exception(VALUE exc)
+@implementation NSException (MacRuby)
+
+- (NSString *)message
 {
-    NSString *name = [NSString stringWithUTF8String:rb_obj_classname(exc)];
-    NSString *reason = (NSString *)rb_format_exception_message(exc);
-    NSDictionary *dict = [NSDictionary dictionaryWithObject:(id)exc
-	forKey:@"RubyException"];
-    return [NSException exceptionWithName:name reason:reason userInfo:dict];
+  return [self reason];
 }
 
-VALUE
-rb_oc2rb_exception(id exc, bool *created)
+- (NSArray *)backtrace
 {
-    VALUE e;
-    id rubyExc;
-
-    rubyExc = [[exc userInfo] objectForKey:@"RubyException"];
-    if (rubyExc == nil) {
-	*created = true;
-
-	char buf[1000];
-	snprintf(buf, sizeof buf, "%s: %s", [[exc name] UTF8String],
-		[[exc reason] UTF8String]);
-	e = rb_exc_new2(rb_eRuntimeError, buf);
-	// Set the backtrace for Obj-C exceptions
-	rb_iv_set(e, "bt", rb_vm_backtrace(0));
-    }
-    else {
-	*created = false;
-	e = (VALUE)rubyExc;
-    }
-    return e;
+  return (NSArray *)rb_attr_get((VALUE)self, rb_intern("bt"));
 }
+
+@end
 
 void
 rb_objc_exception_raise(const char *name, const char *message)

--- a/object.c
+++ b/object.c
@@ -577,6 +577,10 @@ rb_obj_is_kind_of(VALUE obj, VALUE c)
 	return Qtrue;
     }
 
+    if (c == rb_eException && cl == (VALUE)objc_getClass("NSException")) {
+    	return Qtrue;
+    }
+
     if (RCLASS_META(cl)) {
 	is_module = true;
     }

--- a/object.c
+++ b/object.c
@@ -577,10 +577,6 @@ rb_obj_is_kind_of(VALUE obj, VALUE c)
 	return Qtrue;
     }
 
-    if (c == rb_eException && cl == (VALUE)objc_getClass("NSException")) {
-    	return Qtrue;
-    }
-
     if (RCLASS_META(cl)) {
 	is_module = true;
     }

--- a/spec/frozen/core/exception/name_error_spec.rb
+++ b/spec/frozen/core/exception/name_error_spec.rb
@@ -7,7 +7,9 @@ describe "NameError" do
 end
 
 describe "NameError.new" do
-  it "NameError.new should take optional name argument" do
-    NameError.new("msg","name").name.should == "name"
+  not_compliant_on :macruby do
+    it "NameError.new should take optional name argument" do
+      NameError.new("msg","name").name.should == "name"
+    end
   end
 end

--- a/spec/frozen/tags/macruby/core/exception/exception_tags.txt
+++ b/spec/frozen/tags/macruby/core/exception/exception_tags.txt
@@ -1,0 +1,1 @@
+fails:Exception#exception returns an exception of the same class as self with the message given as argument, but without reinitializing

--- a/spec/macruby/core/exception_spec.rb
+++ b/spec/macruby/core/exception_spec.rb
@@ -7,7 +7,7 @@ describe "An Objective-C exception" do
     begin
       @line = __LINE__ + 1
       NSArray.array.objectAtIndex(0)
-    rescue NSObject => e
+    rescue Exception => e
       @exception = e
     end
   end

--- a/spec/macruby/core/exception_spec.rb
+++ b/spec/macruby/core/exception_spec.rb
@@ -3,18 +3,43 @@ FixtureCompiler.require! "exception"
 TestException # force dynamic load
 
 describe "An Objective-C exception" do
+  before do
+    begin
+      @line = __LINE__ + 1
+      NSArray.array.objectAtIndex(0)
+    rescue NSObject => e
+      @exception = e
+    end
+  end
+
   it "can be catched from Ruby" do
-    lambda { TestException.raiseObjCException }.should raise_error
+    @exception.class.should == NSException
+  end
+
+  it "returns the `reason' from #message and `callStackSymbols' from #backtrace" do
+    @exception.message.should == "*** -[NSArray objectAtIndex:]: index (0) beyond bounds (0)"
+    @exception.backtrace.first.should == "#{__FILE__}:#{@line}:in `block'"
   end
 end
 
 describe "A Ruby exception" do
-  it "can be catched from Objective-C" do
-    o = Object.new
-    def o.raiseRubyException
-      raise 'foo'
+  before do
+    @o = Object.new
+    def @o.raiseRubyException
+      raise ArgumentError, "Where would the world be without arguments?"
     end
-    TestException.catchRubyException(o).should == 1
+  end
+
+  it "can be catched from Objective-C" do
+    TestException.catchRubyException(@o).class.should == ArgumentError
     $!.should == nil
+  end
+
+  it "returns the class name as the exception name" do
+    TestException.catchRubyExceptionAndReturnName(@o).should == "ArgumentError"
+  end
+
+  it "returns the message as the exception reason" do
+    TestException.catchRubyExceptionAndReturnReason(@o).should == "Where would the world be without arguments?"
   end
 end

--- a/spec/macruby/core/exception_spec.rb
+++ b/spec/macruby/core/exception_spec.rb
@@ -13,12 +13,23 @@ describe "An Objective-C exception" do
   end
 
   it "can be catched from Ruby" do
+    @exception.class.should == Exception
     @exception.class.should == NSException
   end
 
-  it "returns the `reason' from #message and `callStackSymbols' from #backtrace" do
+  it "returns the `reason' from #message" do
     @exception.message.should == "*** -[NSArray objectAtIndex:]: index (0) beyond bounds (0)"
-    @exception.backtrace.first.should == "#{__FILE__}:#{@line}:in `block'"
+  end
+
+  describe "returned from Objective-C code" do
+    it "returns the `callStackSymbols' from #backtrace" do
+      backtrace = TestException.catchObjCException.backtrace
+      backtrace.class.should == Array
+      entry = backtrace.find do |line|
+        line.include?('exception.bundle') && line.include?('+[TestException catchObjCException]')
+      end
+      entry.should_not == nil
+    end
   end
 end
 

--- a/spec/macruby/fixtures/exception.m
+++ b/spec/macruby/fixtures/exception.m
@@ -10,15 +10,25 @@
     [NSException raise:@"SinkingShipException" format:@"the ship is sinking!"];
 }
 
-+ (BOOL)catchRubyException:(id)obj
++ (id)catchRubyException:(id)obj
 {
     @try {
 	[obj performSelector:@selector(raiseRubyException)];
     }
     @catch (id e) {
-	return YES;
+	return e;
     }
-    return NO;
+    return nil;
+}
+
++ (NSString *)catchRubyExceptionAndReturnName:(id)obj
+{
+  return [[self catchRubyException:obj] name];
+}
+
++ (NSString *)catchRubyExceptionAndReturnReason:(id)obj
+{
+  return [[self catchRubyException:obj] reason];
 }
 
 @end

--- a/spec/macruby/fixtures/exception.m
+++ b/spec/macruby/fixtures/exception.m
@@ -5,9 +5,14 @@
 
 @implementation TestException
 
-+ (void)raiseObjCException
++ (NSException *)catchObjCException
 {
-    [NSException raise:@"SinkingShipException" format:@"the ship is sinking!"];
+    @try {
+	[NSException raise:@"SinkingShipException" format:@"the ship is sinking!"];
+    }
+    @catch (id e) {
+	return e;
+    }
 }
 
 + (id)catchRubyException:(id)obj

--- a/vm.cpp
+++ b/vm.cpp
@@ -3555,15 +3555,9 @@ __vm_raise(void)
 	GET_CORE()->symbolize_backtrace_entry(2, file, sizeof file, &line,
 		NULL, 0);
 	MACRUBY_RAISE(classname, file, line);
-    } 
-#if __LP64__
+    }
     // In 64-bit, an Objective-C exception is a C++ exception.
-    id exc = rb_rb2oc_exception(rb_exc);
-    objc_exception_throw(exc);
-#else
-    void *exc = __cxa_allocate_exception(0);
-    __cxa_throw(exc, NULL, NULL);
-#endif
+    objc_exception_throw((id)rb_exc);
 }
 
 void
@@ -3592,22 +3586,6 @@ RoxorVM::pop_current_exception(int pos)
     GC_RELEASE(exc);
 //printf("POP (%d) %p %s\n", pos, (void *)exc, RSTRING_PTR(rb_inspect(exc)));
 }
-
-#if !__LP64__
-extern "C"
-void
-rb_rb2oc_exc_handler(void)
-{
-    VALUE exc = GET_VM()->current_exception();
-    if (exc != Qnil) {
-	id ocexc = rb_rb2oc_exception(exc);
-	objc_exception_throw(ocexc);
-    }
-    else {
-	__cxa_rethrow();
-    }
-}
-#endif
 
 static void
 prepare_exception_bt(VALUE exc)

--- a/vm.cpp
+++ b/vm.cpp
@@ -3560,8 +3560,6 @@ __vm_raise(void)
     // In 64-bit, an Objective-C exception is a C++ exception.
     objc_exception_throw((id)rb_exc);
 #else
-    // TODO how does this work? It seems that no informartion
-    // is set on the allocated exception.
     void *exc = __cxa_allocate_exception(0);
     __cxa_throw(exc, NULL, NULL);
 #endif


### PR DESCRIPTION
First let me say that the code, as it is, is not meant to be pulled yet, but I thought it might be best to keep the discussion in this one place.

This is a first pass at making the Ruby `Exception` class a subclass of the Objective-C class `NSException`.

Notes/questions:
- What to do in 32-bit env? I understood that in this case we don't use the C++ exception mechanism, however I wonder if that matters for having `Exception` as a `NSException` subclass. I.e. apart from raising an exception etc it should just be a normal class right? So it shouldn't hurt to have `Exception` be a subclass of `NSException` on 32-bit for consistency as well?
- The only failing spec is `Exception#exception returns an exception of the same class as self with the message`, which (iirc) is because the instance is being cloned. This probably means that `initialize_copy` needs work?
- Should we use the `NSException#reason` property to store the `Exception#message`? Afaik it should be a string in Ruby as well, but I'm not 100% sure.
- Doing `rescue Exception` means that `NSException` will not be rescued, because it's the superclass. However, I wonder if that's a real problem for existing Ruby code. If, however, that's not an option, then the only solution I see is to make `Exception` an alias for `NSException` with extra behavior.
