### PR TITLE
ruby_deploy's fix_install_name doesn't perform a deep search in Contents/Resources

### DIFF
--- a/bin/ruby_deploy
+++ b/bin/ruby_deploy
@@ -269,7 +269,7 @@ class Deployer
     log "Fix install path of binaries"
     patterns = [File.join(@app_bundle, 'Contents/MacOS/*'),
                 File.join(app_macruby_usr, 'lib/ruby/**/*.{bundle,rbo}'),
-                File.join(@app_bundle, 'Contents/Resources/*.rbo')]
+                File.join(@app_bundle, 'Contents/Resources/**/*.rbo')]
     patterns.each do |pat|
       Dir.glob(pat).each do |bin|
         execute("#{@install_name_tool} -change #{macruby_usr}/lib/libmacruby.dylib @executable_path/../Frameworks/MacRuby.framework/Versions/Current/usr/lib/libmacruby.dylib '#{bin}'")


### PR DESCRIPTION
compile_files does `Dir.glob(File.join(app_resources, '**', '*.rb'))` but fix_install_name does `Contents/Resources/*.rbo`
