### PR TITLE
fixed bug, could not find constants when cloned Class or Module. (fixes #1337)

### DIFF
--- a/object.c
+++ b/object.c
@@ -192,6 +192,13 @@ rb_obj_class(VALUE obj)
 static void
 init_copy(VALUE dest, VALUE obj)
 {
+    if (NATIVE(obj)) {
+	if (OBJ_TAINTED(obj)) {
+	    OBJ_TAINT(dest);
+	} 
+	goto call_init_copy;
+    }
+
     if (OBJ_FROZEN(dest)) {
         rb_raise(rb_eTypeError, "[bug] frozen object (%s) allocated",
 		rb_obj_classname(dest));
@@ -239,7 +246,7 @@ init_copy(VALUE dest, VALUE obj)
 	}
         break;
     }
-
+call_init_copy:
     rb_vm_call(dest, selInitializeCopy, 1, &obj);
 }
 


### PR DESCRIPTION
## fixed bug, could not find constants when cloned Class or Module. (fixes #1337)

ex)
class A
  CONST="const"
end
B = A.clone
p B::CONST #=> before raise exception, after "const"
