### PR TITLE
Fix for mutex race condition

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -1507,8 +1507,8 @@ rb_mutex_unlock0(VALUE self, bool assert_unlockable,
 	    assert(m->thread->mutexes != Qnil);
 	    rb_ary_delete(m->thread->mutexes, self);
 	}
-	pthread_assert(pthread_mutex_unlock(&m->mutex));
 	m->thread = NULL;
+	pthread_assert(pthread_mutex_unlock(&m->mutex));
     }
 }
 


### PR DESCRIPTION
Partial fix for ticket #542 - Attempt to unlock a mutex which is not locked (ThreadError)

Fix for mutex race condition.  This does not fix the overall problem
using Monitor class.
