### PR TITLE
Make CFBundleExecutable in Info.plist match the actual bundle executable.

### DIFF
--- a/rakelib/builder/templates.rb
+++ b/rakelib/builder/templates.rb
@@ -10,7 +10,7 @@ class Builder
         <key>CFBundleExecutable</key>
         <string>MacRuby</string>
         <key>CFBundleName</key>
-        <string>Ruby</string>
+        <string>MacRuby</string>
         <key>CFBundleGetInfoString</key>
         <string>MacRuby Runtime and Library</string>
         <key>CFBundleIconFile</key>

--- a/rakelib/builder/templates.rb
+++ b/rakelib/builder/templates.rb
@@ -8,7 +8,7 @@ class Builder
         <key>CFBundleDevelopmentRegion</key>
         <string>English</string>
         <key>CFBundleExecutable</key>
-        <string>Ruby</string>
+        <string>MacRuby</string>
         <key>CFBundleName</key>
         <string>Ruby</string>
         <key>CFBundleGetInfoString</key>


### PR DESCRIPTION
Make CFBundleExecutable in Info.plist match the actual bundle executable.

Without this fix, trying to dynamically load MacRuby.framework using
NSBundle results in the following error:
The bundle “Ruby” couldn’t be loaded because its executable couldn’t be located.
