### PR TITLE
This should close out issue #542, attempt to unlock mutex which is not locked.

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -1559,8 +1559,11 @@ mutex_sleep(VALUE self, SEL sel, int argc, VALUE *argv)
 	rb_thread_wait_for(t);
     }
 
+    rb_mutex_lock(self, 0);
+
     end = time(0) - beg;
-    return INT2FIX(end);        
+
+    return INT2FIX(end);
 }
 
 /*


### PR DESCRIPTION
Re-lock the mutex at the end of mutex_sleep in thread.c.
