### PR TITLE
Fix for ticket #203.

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -1120,9 +1120,7 @@ rb_ivar_foreach(VALUE obj, int (*func)(ANYARGS), st_data_t arg)
 static int
 ivar_i(ID key, VALUE val, VALUE ary)
 {
-    if (rb_is_instance_id(key)) {
-	rb_ary_push(ary, ID2SYM(key));
-    }
+    rb_ary_push(ary, ID2SYM(key));
     return ST_CONTINUE;
 }
 


### PR DESCRIPTION
Revert behavior to CRuby.  Internal classes don't necessarily put an '@'
at the beginning of instance variables, so we need to ignore it.

The alternative to this would be to go through all of the internal classes and make sure all instance variables are pre-pended with the '@' character.  This does not only affect the exception class.
