### PR TITLE
When Hash#dup is called, duplicate instance variables

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -154,6 +154,7 @@ rhash_copy(VALUE rcv, VALUE klass)
     GC_WB(&dup->tbl, st_copy(RHASH(rcv)->tbl));
     GC_WB(&dup->ifnone, RHASH(rcv)->ifnone);
     dup->has_proc_default = RHASH(rcv)->has_proc_default;
+    rb_copy_generic_ivar((VALUE)dup, rcv);
     return (VALUE)dup;
 }
 

--- a/spec/macruby/core/hash_spec.rb
+++ b/spec/macruby/core/hash_spec.rb
@@ -45,6 +45,17 @@ describe "An Hash object" do
     a.foo.should == 42
   end
 
+  it "clones instance variables to new copy on #dup" do
+    class CustomHash < Hash
+      attr_accessor :foo
+    end
+    my_hash = CustomHash.new
+    my_hash.foo = :bar
+
+    new_hash = my_hash.dup
+    new_hash.foo.should == :bar
+  end
+
   it "properly hashes pure Cocoa objects" do
     a = NSCalendarDate.dateWithYear(2010, month:5, day:2, hour:0,  minute:0, second:0, timeZone:nil)
     b = NSCalendarDate.dateWithYear(2010, month:5, day:2, hour:0,  minute:0, second:0, timeZone:nil)


### PR DESCRIPTION
When Hash#dup was called, resulting hash was returned without instance variables of original hash.

This resulted in strange exceptions being raised in Sinatra, because Rack::Utils::HeaderHash#merge relied on ivars being copied upon #dup call
