### PR TITLE
Make rexml use the compiled files

### DIFF
--- a/lib/rexml/encoding.rb
+++ b/lib/rexml/encoding.rb
@@ -31,11 +31,11 @@ module REXML
           raise ArgumentError, "Bad encoding name #@encoding" unless @encoding =~ /^[\w-]+$/
           @encoding.untaint
           begin
-            require 'rexml/encodings/ICONV.rb'
+            require 'rexml/encodings/ICONV'
             Encoding.apply(self, "ICONV")
           rescue LoadError, Exception
             begin
-              enc_file = File.join( "rexml", "encodings", "#@encoding.rb" )
+              enc_file = File.join( "rexml", "encodings", "#@encoding" )
               require enc_file
               Encoding.apply(self, @encoding)
             rescue LoadError => err
@@ -45,7 +45,7 @@ module REXML
           end
         else
           @encoding = UTF_8
-          require 'rexml/encodings/UTF-8.rb'
+          require 'rexml/encodings/UTF-8'
           Encoding.apply(self, @encoding)
         end
       ensure


### PR DESCRIPTION
There was a report on the mailing list about the issue:

[http://lists.macosforge.org/pipermail/macruby-devel/2011-October/008107.html](issue)

I believe this change will work, but I'm having a bit of a hard time making sure that I tested that the compiled version actually works. I can haz halp, plz?
