### PR TITLE
Change gem installation and executable directories

### DIFF
--- a/lib/rubygems/defaults/macruby.rb
+++ b/lib/rubygems/defaults/macruby.rb
@@ -8,4 +8,9 @@ module Gem
   Platform::MACRUBY_CURRENT = Platform.new([Platform.local.cpu, RUBY_ENGINE,
                                             MACRUBY_VERSION.split('.')[0, 2].join('.')])
   platforms << Platform::MACRUBY_CURRENT
+
+  def self.default_dir
+    "/Library/Ruby/Gems/MacRuby/#{MACRUBY_VERSION.to_f}"
+  end
+
 end

--- a/rakelib/builder/templates.rb
+++ b/rakelib/builder/templates.rb
@@ -243,7 +243,6 @@ module RbConfig
 end
 Config = RbConfig # compatibility for ruby-1.8.4 and older.
 CROSS_COMPILING = nil
-RUBY_FRAMEWORK = true
 EOS
     if !File.exist?('rbconfig.rb') or File.read('rbconfig.rb') != rbconfig
       File.open('rbconfig.rb', 'w') { |io| io.print rbconfig }

--- a/rakelib/builder/templates.rb
+++ b/rakelib/builder/templates.rb
@@ -244,7 +244,6 @@ end
 Config = RbConfig # compatibility for ruby-1.8.4 and older.
 CROSS_COMPILING = nil
 RUBY_FRAMEWORK = true
-RUBY_FRAMEWORK_VERSION = RbConfig::CONFIG['ruby_version']
 EOS
     if !File.exist?('rbconfig.rb') or File.read('rbconfig.rb') != rbconfig
       File.open('rbconfig.rb', 'w') { |io| io.print rbconfig }

--- a/rakelib/builder/templates.rb
+++ b/rakelib/builder/templates.rb
@@ -70,7 +70,7 @@ module RbConfig
   CONFIG["PACKAGE_STRING"] = ""
   CONFIG["PACKAGE_BUGREPORT"] = ""
   CONFIG["exec_prefix"] = "$(prefix)"
-  CONFIG["bindir"] = "$(exec_prefix)/bin"
+  CONFIG["bindir"] = "#{SYM_INSTDIR}/bin"
   CONFIG["sbindir"] = "$(exec_prefix)/sbin"
   CONFIG["libexecdir"] = "$(exec_prefix)/libexec"
   CONFIG["datarootdir"] = "$(prefix)/share"


### PR DESCRIPTION
I think I have finished off all the changes discussed in this trac ticket: http://www.macruby.org/trac/ticket/574

These are the new gem directories:

INSTALLATION DIRECTORY: /Library/Ruby/Gems/MacRuby
EXECUTABLE DIRECTORY: /usr/local/bin

I have also removed the RUBY_FRAMEWORK_VERSION constant, which doesn't appear to be necessary anymore.

These changes seem to work well for me, but this is the first time I've touched this code so I may be overlooking some side effects.  Any feedback is welcome!

Cheers,
Isaac
