### PR TITLE
This change fixes #530, Net::SSH failure.

### DIFF
--- a/string.c
+++ b/string.c
@@ -179,6 +179,14 @@ str_compatible_encoding(rb_str_t *str1, rb_str_t *str2)
     if (str1->length_in_bytes == 0) {
 	return str2->encoding;
     }
+    if (str1->encoding->index == ENCODING_BINARY)
+    {
+    	return str1->encoding;
+    }
+    if (str2->encoding->index == ENCODING_BINARY)
+    {
+    	return str2->encoding;
+    }
     if (!str1->encoding->ascii_compatible
 	    || !str2->encoding->ascii_compatible) {
 	return NULL;


### PR DESCRIPTION
In the same way that UTF-8 sucks in all ASCII compatible strings and the result is UTF-8, any string that is ASCII-8BIT (BINARY, internally) will suck in anything that is combined with it and the result will be ASCII-8BIT (BINARY).

Funny thing is I came up with a reduction that fails in macruby and 1.9.3, but Net:SSH fails in macuby and works in 1.9.3!  Go figure.
