### PR TITLE
Codesign fix

### DIFF
--- a/bin/ruby_deploy
+++ b/bin/ruby_deploy
@@ -22,15 +22,15 @@ class Deployer
 
     OptionParser.new do |opts|
       opts.banner = "Usage: #{NAME} [options] application-bundle"
-      opts.on('--compile',       'Compile the bundle source code') { @compile = true }
-      opts.on('--embed',         'Embed MacRuby inside the bundle') { @embed = true }
-      opts.on('--no-stdlib',     'Do not embed the standard library') { @no_stdlib = true }
-      opts.on('--stdlib [LIB]',  'Embed only LIB from the standard library') { |lib| @stdlib << lib }
-      opts.on('--gem [GEM]',     'Embed GEM and its dependencies') { |gem| @gems << gem }
-      opts.on('--bs',            'Embed the system BridgeSupport files') { @embed_bs = true }
-      opts.on('--verbose',       'Log all commands to standard out') { @verbose = true }
-      opts.on('--codesign',      'Sign the files with the specified certificate') { |cert| @certificate = cert }
-      opts.on('-v', '--version', 'Display the version') do
+      opts.on('--compile',                    'Compile the bundle source code') { @compile = true }
+      opts.on('--embed',                      'Embed MacRuby inside the bundle') { @embed = true }
+      opts.on('--no-stdlib',                  'Do not embed the standard library') { @no_stdlib = true }
+      opts.on('--stdlib [LIB]',               'Embed only LIB from the standard library') { |lib| @stdlib << lib }
+      opts.on('--gem [GEM]',                  'Embed GEM and its dependencies') { |gem| @gems << gem }
+      opts.on('--bs',                         'Embed the system BridgeSupport files') { @embed_bs = true }
+      opts.on('--verbose',                    'Log all commands to standard out') { @verbose = true }
+      opts.on('--codesign [CERT]', String,    'Sign the files with the specified certificate') { |cert| @certificate = cert }
+      opts.on('-v', '--version',              'Display the version') do
         puts RUBY_DESCRIPTION
         exit 1
       end
@@ -328,17 +328,16 @@ class Deployer
     log "Using codesign to sign files with #{@certificate}"
     files = []
     #get the .bundle, .rbo, .rb, .dylib, and .framework
-    files << Dir.glob(File.join(@app_bundle, '**', '*.bundle'))
-    files << Dir.glob(File.join(@app_bundle, '**', '*.rbo'))
-    files << Dir.glob(File.join(@app_bundle, '**', '*.rb'))
-    files << Dir.glob(File.join(@app_bundle, '**', '*.dylib'))
-    files << Dir.glob(File.join(@app_bundle, '**', '*.framework'))
+    files += Dir.glob(File.join(@app_bundle, '**', '*.bundle'))
+    files += Dir.glob(File.join(@app_bundle, '**', '*.rbo'))
+    files += Dir.glob(File.join(@app_bundle, '**', '*.rb'))
+    files += Dir.glob(File.join(@app_bundle, '**', '*.dylib'))
+    files += Dir.glob(File.join(@app_bundle, '**', '*.framework'))
     files << @app_bundle
 
-    #loop through the files found, codesign them
-    files.each do |file|
-      execute("/usr/bin/codesign -f -s #{@certificate}")
-    end
+    #loop through the files found, codesign them, with fource and replace switches
+
+    execute("/usr/bin/codesign -f -s \"#{@certificate}\" #{files.join(' ')}")
   end
 end
 

--- a/bin/ruby_deploy
+++ b/bin/ruby_deploy
@@ -335,9 +335,7 @@ class Deployer
     files += Dir.glob(File.join(@app_bundle, '**', '*.framework'))
     files << @app_bundle
 
-    #loop through the files found, codesign them, with fource and replace switches
-
-    execute("/usr/bin/codesign -f -s \"#{@certificate}\" #{files.join(' ')}")
+    execute("/usr/bin/codesign -f -s \"#{@certificate}\" #{files.collect {|f| "\"#{f}\"" }.join(' ')}")
   end
 end
 

--- a/bin/ruby_deploy
+++ b/bin/ruby_deploy
@@ -29,6 +29,7 @@ class Deployer
       opts.on('--gem [GEM]',     'Embed GEM and its dependencies') { |gem| @gems << gem }
       opts.on('--bs',            'Embed the system BridgeSupport files') { @embed_bs = true }
       opts.on('--verbose',       'Log all commands to standard out') { @verbose = true }
+      opts.on('--codesign',      'Sign the files with the specified certificate') { |cert| @certificate = cert }
       opts.on('-v', '--version', 'Display the version') do
         puts RUBY_DESCRIPTION
         exit 1
@@ -72,6 +73,7 @@ class Deployer
     log "Deployment started"
     embed if @embed
     compile if @compile
+    sign if @certificate
     log "Deployment ended"
   end
 
@@ -320,6 +322,22 @@ class Deployer
 
   def log(msg)
     $stderr.puts "*** #{msg}"
+  end
+
+  def sign
+    log "Using codesign to sign files with #{@certificate}"
+    files = []
+    #get the .bundle, .rbo, .rb, and .framework
+    files << Dir.glob(File.join(@app_bundle, '**', '*.bundle'))
+    files << Dir.glob(File.join(@app_bundle, '**', '*.rbo'))
+    files << Dir.glob(File.join(@app_bundle, '**', '*.rb'))
+    files << Dir.glob(File.join(@app_bundle, '**', '*.framework'))
+    files << @app_bundle
+
+    #loop through the files found, codesign them
+    files.each do |file|
+      execute("/usr/bin/codesign -f -s #{@certificate}")
+    end
   end
 end
 

--- a/bin/ruby_deploy
+++ b/bin/ruby_deploy
@@ -327,10 +327,11 @@ class Deployer
   def sign
     log "Using codesign to sign files with #{@certificate}"
     files = []
-    #get the .bundle, .rbo, .rb, and .framework
+    #get the .bundle, .rbo, .rb, .dylib, and .framework
     files << Dir.glob(File.join(@app_bundle, '**', '*.bundle'))
     files << Dir.glob(File.join(@app_bundle, '**', '*.rbo'))
     files << Dir.glob(File.join(@app_bundle, '**', '*.rb'))
+    files << Dir.glob(File.join(@app_bundle, '**', '*.dylib'))
     files << Dir.glob(File.join(@app_bundle, '**', '*.framework'))
     files << @app_bundle
 


### PR DESCRIPTION
As it stands, macruby_deploy modifies the app bundle, nullifying any code signing that takes place in Xcode. This causes the app to be rejected when submitted to the MAS review process, and endless hours of confusing and troubleshooting trying to fix it. The solution is to manually enter the bundle and run the codesign utility on all the modified files and the app bundle.

I've added a --codesign switch to the script that accepts the name of your third party certificate to re-sign all the changed files. An example would be 

```--codesign "3rd Party Mac Developer Application: Daniel Westendorf"

```

This finds all the .bundle, .rbo, .rb, .framework, and .dylib files and signs them, then signs the entire bundle. I've tested this on a real MAS app submission, and it returned no errors.
```
