### PR TITLE
Fix issue 1468: Better management of debugging #defines

### DIFF
--- a/compiler.cpp
+++ b/compiler.cpp
@@ -8,7 +8,7 @@
 
 #if !defined(MACRUBY_STATIC)
 
-#define ROXOR_COMPILER_DEBUG 	0
+#include "debug_config.h"
 
 #if !defined(DW_LANG_Ruby)
 # define DW_LANG_Ruby 0x15 // TODO: Python is 0x14, request a real number

--- a/debug_config.h
+++ b/debug_config.h
@@ -1,0 +1,11 @@
+#ifndef ROXOR_COMPILER_DEBUG
+#define ROXOR_COMPILER_DEBUG 	0
+#endif
+
+#ifndef ROXOR_VM_DEBUG
+#define ROXOR_VM_DEBUG		0
+#endif
+
+#ifndef ROXOR_VM_DEBUG_CONST
+#define ROXOR_VM_DEBUG_CONST		0
+#endif

--- a/dispatcher.cpp
+++ b/dispatcher.cpp
@@ -19,7 +19,8 @@
 #include <execinfo.h>
 #include <dlfcn.h>
 
-#define ROXOR_VM_DEBUG		0
+#include "debug_config.h"
+
 #define MAX_DISPATCH_ARGS 	100
 
 static force_inline void

--- a/vm.cpp
+++ b/vm.cpp
@@ -6,9 +6,7 @@
  * Copyright (C) 2008-2011, Apple Inc. All rights reserved.
  */
 
-#define ROXOR_VM_DEBUG		0
-#define ROXOR_COMPILER_DEBUG 	0
-#define ROXOR_VM_DEBUG_CONST	0
+#include "debug_config.h"
 
 #if MACRUBY_STATIC
 # include <vector>


### PR DESCRIPTION
Collect debugging `#define`s into a new single header file called `config.h` and wrap them with `#ifndef`'s so that they can be set on the rake command-line -- e.g.:

```
CFLAGS="-DROXOR_VM_DEBUG -DROXOR_VM_DEBUG_CONST -DROXOR_COMPILER_DEBUG" rake
```

Here it is in action:

```
[last: 0] marca@SCML-MarcA:~/dev/git-repos/MacRuby$ touch vm.cpp compiler.cpp dispatcher.cpp 
[last: 0] marca@SCML-MarcA:~/dev/git-repos/MacRuby$ CFLAGS="-DROXOR_VM_DEBUG -DROXOR_VM_DEBUG_CONST -DROXOR_COMPILER_DEBUG" rake
(in /Users/marca/dev/git-repos/MacRuby)
/usr/bin/g++ -I. -I./include -fblocks -g -Wall -Wno-deprecated-declarations -Werror -arch x86_64 -DROXOR_VM_DEBUG -DROXOR_VM_DEBUG_CONST -DROXOR_COMPILER_DEBUG -I/usr/local/include  -D_DEBUG -D_GNU_SOURCE -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -O3   -fno-rtti -fno-common -Woverloaded-virtual -I./icu-1060 -c compiler.cpp -o .objs/compiler.o
/usr/bin/g++ -I. -I./include -fblocks -g -Wall -Wno-deprecated-declarations -Werror -arch x86_64 -DROXOR_VM_DEBUG -DROXOR_VM_DEBUG_CONST -DROXOR_COMPILER_DEBUG -I/usr/local/include  -D_DEBUG -D_GNU_SOURCE -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -O3   -fno-rtti -fno-common -Woverloaded-virtual -I./icu-1060 -x objective-c++ -c dispatcher.cpp -o .objs/dispatcher.o
/usr/bin/g++ -I. -I./include -fblocks -g -Wall -Wno-deprecated-declarations -Werror -arch x86_64 -DROXOR_VM_DEBUG -DROXOR_VM_DEBUG_CONST -DROXOR_COMPILER_DEBUG -I/usr/local/include  -D_DEBUG -D_GNU_SOURCE -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -O3   -fno-rtti -fno-common -Woverloaded-virtual -I./icu-1060 -c vm.cpp -o .objs/vm.o
./markgc .objs/dispatcher.o
patched .objs/dispatcher.o at offset 0xed45c
/usr/bin/g++ -std=c99 -I. -I./include -pipe -fno-common -fexceptions -fblocks -fwrapv -g -O3 -Wall -Wno-deprecated-declarations -Werror -arch x86_64 -DROXOR_VM_DEBUG -DROXOR_VM_DEBUG_CONST -DROXOR_COMPILER_DEBUG -I./icu-1060 .objs/array.o .objs/bignum.o .objs/class.o .objs/compar.o .objs/complex.o .objs/enum.o .objs/enumerator.o .objs/error.o .objs/eval.o .objs/file.o .objs/load.o .objs/proc.o .objs/gc.o .objs/hash.o .objs/env.o .objs/inits.o .objs/io.o .objs/math.o .objs/numeric.o .objs/object.o .objs/pack.o .objs/parse.o .objs/prec.o .objs/dir.o .objs/process.o .objs/random.o .objs/range.o .objs/rational.o .objs/re.o .objs/ruby.o .objs/signal.o .objs/sprintf.o .objs/st.o .objs/string.o .objs/struct.o .objs/time.o .objs/util.o .objs/variable.o .objs/version.o .objs/thread.o .objs/id.o .objs/objc.o .objs/bs.o .objs/ucnv.o .objs/encoding.o .objs/main.o .objs/dln.o .objs/dmyext.o .objs/marshal.o .objs/gcd.o .objs/vm_eval.o .objs/gc-stub.o .objs/bridgesupport.o .objs/compiler.o .objs/dispatcher.o .objs/vm.o .objs/symbol.o .objs/debugger.o .objs/interpreter.o .objs/MacRuby.o .objs/MacRubyDebuggerConnector.o .objs/NSArray.o .objs/NSDictionary.o .objs/NSString.o .objs/transcode.o .objs/sandbox.o -lpthread -ldl -lxml2 -lobjc -licucore -framework Foundation -lauto -L/usr/local/lib  -lpthread -lm -lLLVMipo -lLLVMBitReader -lLLVMBitWriter -lLLVMX86CodeGen -lLLVMX86Info -lLLVMX86AsmPrinter -lLLVMX86Utils -lLLVMSelectionDAG -lLLVMAsmPrinter -lLLVMMCParser -lLLVMJIT -lLLVMExecutionEngine -lLLVMCodeGen -lLLVMScalarOpts -lLLVMInstCombine -lLLVMTransformUtils -lLLVMipa -lLLVMAnalysis -lLLVMTarget -lLLVMMC -lLLVMCore -lLLVMSupport -o miniruby
...
```

Fixes https://www.macruby.org/trac/ticket/1468
