### PR TITLE
Add a ChangeLog to the MacRuby source so we can keep track as we go

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -1,0 +1,15 @@
+# 0.12
+
+MacRuby 0.12 was a milestone release...
+
+ * Add support for XCode 4.3
+ * Drop support for XCode 4.2 and earlier
+ * Upgrade to RubyGems 1.8.x
+ * Upgrade to Rake 0.9.x
+ * Add the `--codesign` option to `macruby_deploy`
+ * Gems are now installed to `/Library/Ruby/Gems/MacRuby`
+ * Remove obsoleted constants `RUBY_FRAMEWORK` and `RUBY_FRAMEWORK_VERSION` from `RbConfig`
+ * macrubyc now uses proper exit codes for `--help` and `--version` options
+ * The `instruby.rb` script has been replaced with a set of rake tasks
+
+![Business Cat Doin His Thang](http://i.imgur.com/2KmJW.jpg)


### PR DESCRIPTION
I propose we keep track of notable changes to MacRuby in a ChangeLog as we go. I think this would mitigate the small mountain that needs to be climbed creating release notes when MacRuby is on the cusp of a new release.

I've started the file and added things that I have taken part since the master branch changed to 0.12.
