### PR TITLE
Begin a new era for MacRuby

### DIFF
--- a/MacRuby.m
+++ b/MacRuby.m
@@ -1,8 +1,9 @@
 /*
  * MacRuby Objective-C API.
- * 
+ *
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2009-2011, Apple Inc. All rights reserved.
  */
 

--- a/MacRubyDebuggerConnector.h
+++ b/MacRubyDebuggerConnector.h
@@ -7,7 +7,8 @@
  * enabled.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2010-2011, Apple Inc. All rights reserved.
  */
 

--- a/MacRubyDebuggerConnector.m
+++ b/MacRubyDebuggerConnector.m
@@ -2,7 +2,8 @@
  * MacRuby Debugger Connector.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2010-2011, Apple Inc. All rights reserved.
  */
 

--- a/NSArray.m
+++ b/NSArray.m
@@ -1,8 +1,9 @@
 /*
  * MacRuby extensions to NSArray.
- * 
+ *
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2010-2011, Apple Inc. All rights reserved.
  */
 

--- a/NSDictionary.m
+++ b/NSDictionary.m
@@ -1,8 +1,9 @@
 /*
  * MacRuby extensions to NSDictionary.
- * 
+ *
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2010-2011, Apple Inc. All rights reserved.
  */
 

--- a/NSString.m
+++ b/NSString.m
@@ -1,8 +1,9 @@
 /*
  * MacRuby extensions to NSString.
- * 
+ *
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2010-2011, Apple Inc. All rights reserved.
  */
 

--- a/array.c
+++ b/array.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby implementation of Ruby 1.9's array.c.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000 Network Applied Communication Laboratory, Inc.

--- a/array.h
+++ b/array.h
@@ -2,7 +2,8 @@
  * MacRuby Array.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2011, Apple Inc. All rights reserved.
  */
 

--- a/bignum.c
+++ b/bignum.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/bin/rb_nibtool
+++ b/bin/rb_nibtool
@@ -4,6 +4,7 @@
 #
 # This file is covered by the Ruby license.
 #
+# Copyright (C) 2012, The MacRuby Team
 # Copyright (C) 2008-2010, Apple Inc
 
 require 'optparse'

--- a/bin/ruby_deploy
+++ b/bin/ruby_deploy
@@ -3,6 +3,7 @@
 #
 # This file is covered by the Ruby license.
 #
+# Copyright (C) 2012, The MacRuby Team
 # Copyright (C) 2009-2011, Apple Inc
 
 require 'optparse'

--- a/bin/ruby_select
+++ b/bin/ruby_select
@@ -2,6 +2,7 @@
 #
 # This file is covered by the Ruby license.
 #
+# Copyright (C) 2012, The MacRuby Team
 # Copyright (C) 2009-2011, Apple Inc
 
 MACRUBY_FRAMEWORK = '/Library/Frameworks/MacRuby.framework'

--- a/bin/rubyc
+++ b/bin/rubyc
@@ -3,6 +3,7 @@
 #
 # This file is covered by the Ruby license.
 #
+# Copyright (C) 2012, The MacRuby Team
 # Copyright (C) 2009-2011, Apple Inc
 
 require 'optparse'

--- a/bin/rubyd
+++ b/bin/rubyd
@@ -3,6 +3,7 @@
 #
 # This file is covered by the Ruby license.
 #
+# Copyright (C) 2012, The MacRuby Team
 # Copyright (C) 2010-2011, Apple Inc
 
 require 'readline'

--- a/bridgesupport.cpp
+++ b/bridgesupport.cpp
@@ -3,6 +3,7 @@
  *
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  */
 

--- a/bridgesupport.h
+++ b/bridgesupport.h
@@ -2,7 +2,8 @@
  * MacRuby BridgeSupport implementation.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  */
 

--- a/bs.c
+++ b/bs.c
@@ -1,4 +1,5 @@
-/*  
+/*
+ *  Copyright (c) 2012, The MacRuby Team. All rights reserved.
  *  Copyright (c) 2008-2011, Apple Inc. All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/bs.h
+++ b/bs.h
@@ -1,4 +1,5 @@
-/*  
+/*
+ *  Copyright (c) 2012, The MacRuby Team. All rights reserved.
  *  Copyright (c) 2008-2011, Apple Inc. All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/class.c
+++ b/class.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby implementation of Ruby 1.9's class.c.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000 Network Applied Communication Laboratory, Inc.

--- a/class.h
+++ b/class.h
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2011, Apple Inc. All rights reserved.
  */
 

--- a/compar.c
+++ b/compar.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/compiler.cpp
+++ b/compiler.cpp
@@ -2,7 +2,8 @@
  * MacRuby Compiler.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2008-2011, Apple Inc. All rights reserved.
  */
 

--- a/compiler.h
+++ b/compiler.h
@@ -2,7 +2,8 @@
  * MacRuby Compiler.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2008-2011, Apple Inc. All rights reserved.
  */
 

--- a/complex.c
+++ b/complex.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2009-2011, Apple Inc. All rights reserved.
  * Copyright (C) 2008-2009, Tadayoshi Funaba
  */

--- a/debugger.cpp
+++ b/debugger.cpp
@@ -2,7 +2,8 @@
  * MacRuby debugger.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2010-2011, Apple Inc. All rights reserved.
  */
 

--- a/debugger.h
+++ b/debugger.h
@@ -2,7 +2,8 @@
  * MacRuby debugger.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2010-2011, Apple Inc. All rights reserved.
  */
 

--- a/dir.c
+++ b/dir.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000  Network Applied Communication Laboratory, Inc.

--- a/dispatcher.cpp
+++ b/dispatcher.cpp
@@ -2,7 +2,8 @@
  * MacRuby Dispatcher.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2008-2011, Apple Inc. All rights reserved.
  */
 

--- a/dln.c
+++ b/dln.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/encoding.c
+++ b/encoding.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby implementation of Ruby 1.9 String.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000 Network Applied Communication Laboratory, Inc.

--- a/encoding.h
+++ b/encoding.h
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby implementation of Ruby 1.9 String.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000 Network Applied Communication Laboratory, Inc.

--- a/encoding_ucnv.h
+++ b/encoding_ucnv.h
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby implementation of Ruby 1.9 String.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000 Network Applied Communication Laboratory, Inc.

--- a/enum.c
+++ b/enum.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/enumerator.c
+++ b/enumerator.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 2001-2003 Akinori MUSHA
  */

--- a/env.c
+++ b/env.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby implementation of ENV.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000 Network Applied Communication Laboratory, Inc.

--- a/error.c
+++ b/error.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/eval.c
+++ b/eval.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby implementation of Ruby 1.9's eval.c.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000 Network Applied Communication Laboratory, Inc.

--- a/eval_error.c
+++ b/eval_error.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000 Network Applied Communication Laboratory, Inc.

--- a/eval_jump.c
+++ b/eval_jump.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000 Network Applied Communication Laboratory, Inc.

--- a/eval_safe.c
+++ b/eval_safe.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000 Network Applied Communication Laboratory, Inc.

--- a/ext/libyaml/rubyext.c
+++ b/ext/libyaml/rubyext.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby libYAML API.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2009-2010, Apple Inc. All rights reserved.
  */
 

--- a/ext/zlib/zlib.c
+++ b/ext/zlib/zlib.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby Zlib API.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2010, Apple Inc. All rights reserved.
  * Copyright (C) UENO Katsuhiro 2000-2003
  */

--- a/file.c
+++ b/file.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000  Network Applied Communication Laboratory, Inc.

--- a/gc-stub.m
+++ b/gc-stub.m
@@ -1,4 +1,5 @@
-/*  
+/*
+ *  Copyright (C) 2012, The MacRuby Team. All rights reserved.
  *  Copyright (c) 2008-2011, Apple Inc. All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/gc.c
+++ b/gc.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby implementation of Ruby 1.9's gc.c.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000 Network Applied Communication Laboratory, Inc.

--- a/gcd.c
+++ b/gcd.c
@@ -2,7 +2,8 @@
  * MacRuby API for Grand Central Dispatch.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2009-2011, Apple Inc. All rights reserved.
  */
 

--- a/gcd.h
+++ b/gcd.h
@@ -2,7 +2,8 @@
  * MacRuby API for Grand Central Dispatch.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2009-2011, Apple Inc. All rights reserved.
  */
 

--- a/hash.c
+++ b/hash.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby implementation of Ruby 1.9's hash.c.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000 Network Applied Communication Laboratory, Inc.

--- a/hash.h
+++ b/hash.h
@@ -1,6 +1,7 @@
-/* 
+/*
  * MacRuby Hash.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2011, Apple Inc. All rights reserved.
  */
 

--- a/id.c
+++ b/id.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 2004-2007 Koichi Sasada
  */

--- a/id.h
+++ b/id.h
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 2007 Koichi Sasada
  */

--- a/include/MacRuby.h
+++ b/include/MacRuby.h
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2010, Apple Inc. All rights reserved
  */
 

--- a/include/ruby.h
+++ b/include/ruby.h
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2010, Apple Inc. All rights reserved
  * Copyright (C) 2007-2008 Yukihiro Matsumoto
  */

--- a/include/ruby/defines.h
+++ b/include/ruby/defines.h
@@ -1,9 +1,10 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2010, Apple Inc. All rights reserved
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
- */ 
+ */
 
 #ifndef RUBY_DEFINES_H
 #define RUBY_DEFINES_H 1

--- a/include/ruby/encoding.h
+++ b/include/ruby/encoding.h
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2010, Apple Inc. All rights reserved
  * Copyright (C) 2007 Yukihiro Matsumoto
  */

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2010, Apple Inc. All rights reserved
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000  Network Applied Communication Laboratory, Inc.

--- a/include/ruby/io.h
+++ b/include/ruby/io.h
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2010, Apple Inc. All rights reserved
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/include/ruby/node.h
+++ b/include/ruby/node.h
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2010, Apple Inc. All rights reserved
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/include/ruby/objc.h
+++ b/include/ruby/objc.h
@@ -1,7 +1,8 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  *
- * Copyright (C) 2007-2010, Apple Inc. All rights reserved 
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
+ * Copyright (C) 2007-2010, Apple Inc. All rights reserved
  */
 
 #if __OBJC__

--- a/include/ruby/re.h
+++ b/include/ruby/re.h
@@ -1,7 +1,8 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  *
- * Copyright (C) 2007-2010, Apple Inc. All rights reserved 
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
+ * Copyright (C) 2007-2010, Apple Inc. All rights reserved
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */
 

--- a/include/ruby/ruby.h
+++ b/include/ruby/ruby.h
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2010, Apple Inc. All rights reserved
  * Copyright (C) 1993-2008 Yukihiro Matsumoto
  * Copyright (C) 2000  Network Applied Communication Laboratory, Inc.

--- a/include/ruby/signal.h
+++ b/include/ruby/signal.h
@@ -1,7 +1,8 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  *
- * Copyright (C) 2007-2010, Apple Inc. All rights reserved 
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
+ * Copyright (C) 2007-2010, Apple Inc. All rights reserved
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */
 

--- a/include/ruby/util.h
+++ b/include/ruby/util.h
@@ -1,7 +1,8 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  *
- * Copyright (C) 2007-2010, Apple Inc. All rights reserved 
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
+ * Copyright (C) 2007-2010, Apple Inc. All rights reserved
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */
 

--- a/include/rubyio.h
+++ b/include/rubyio.h
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2010, Apple Inc. All rights reserved
  */
 

--- a/include/rubysig.h
+++ b/include/rubysig.h
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2010, Apple Inc. All rights reserved
  */
 

--- a/inits.c
+++ b/inits.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -2,7 +2,8 @@
  * MacRuby Interpreter.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2008-2011, Apple Inc. All rights reserved.
  */
 

--- a/interpreter.h
+++ b/interpreter.h
@@ -2,7 +2,8 @@
  * MacRuby Interpreter.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2008-2011, Apple Inc. All rights reserved.
  */
 

--- a/io.c
+++ b/io.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby implementation of Ruby 1.9's io.c.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000 Network Applied Communication Laboratory, Inc.

--- a/kernel.c
+++ b/kernel.c
@@ -4,7 +4,8 @@
  * code MacRuby generates.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2011, Apple Inc. All rights reserved.
  */
 

--- a/lib/stringio.rb
+++ b/lib/stringio.rb
@@ -2,6 +2,7 @@
 #
 # This file is covered by the Ruby license. See COPYING for more details.
 #
+# Copyright (C) 2012, The MacRuby Team. All rights reserved.
 # Copyright (C) 2009-2011, Apple Inc. All rights reserved.
 
 class StringIO

--- a/lib/strscan.rb
+++ b/lib/strscan.rb
@@ -2,6 +2,7 @@
 #
 # This file is covered by the Ruby license. See COPYING for more details.
 #
+# Copyright (C) 2012, The MacRuby Team. All rights reserved.
 # Copyright (C) 2009-2011, Apple Inc. All rights reserved.
 
 class ScanError < StandardError; end

--- a/load.c
+++ b/load.c
@@ -2,7 +2,8 @@
  * MacRuby file loader.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2009-2011, Apple Inc. All rights reserved.
  */
 

--- a/macruby_internal.h
+++ b/macruby_internal.h
@@ -1,7 +1,8 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  *
- * Copyright (C) 2007-2011, Apple Inc. All rights reserved 
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
+ * Copyright (C) 2007-2011, Apple Inc. All rights reserved
  */
 
 #ifndef __MACRUBY_INTERNAL_H

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/marshal.c
+++ b/marshal.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/math.c
+++ b/math.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/numeric.c
+++ b/numeric.c
@@ -3,6 +3,7 @@
  * 
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/objc.h
+++ b/objc.h
@@ -2,7 +2,8 @@
  * MacRuby ObjC helpers.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  */
 

--- a/objc.m
+++ b/objc.m
@@ -2,7 +2,8 @@
  * MacRuby ObjC helpers.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  */
 

--- a/object.c
+++ b/object.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby implementation of Ruby 1.9's object.c.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000 Network Applied Communication Laboratory, Inc.

--- a/pack.c
+++ b/pack.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/parse.y
+++ b/parse.y
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  * 
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2010, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/prec.c
+++ b/prec.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/proc.c
+++ b/proc.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby implementation of Ruby 1.9's proc.c.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 2004-2007 Koichi Sasada
  */

--- a/process.c
+++ b/process.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000  Network Applied Communication Laboratory, Inc.

--- a/random.c
+++ b/random.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * Random Numbers.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/range.c
+++ b/range.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/rational.c
+++ b/rational.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2009-2011, Apple Inc. All rights reserved.
  * Copyright (C) 2008-2009, Tadayoshi Funaba
  */

--- a/re.c
+++ b/re.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby Regular Expressions.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/re.h
+++ b/re.h
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby Regular Expressions.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2011, Apple Inc. All rights reserved.
  */
 

--- a/ruby.c
+++ b/ruby.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000  Network Applied Communication Laboratory, Inc.

--- a/sandbox.c
+++ b/sandbox.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby interface to sandbox/seatbelt.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2011, Apple Inc. All rights reserved.
  */
 

--- a/signal.c
+++ b/signal.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000  Network Applied Communication Laboratory, Inc.

--- a/sprintf.c
+++ b/sprintf.c
@@ -3,6 +3,7 @@
  *
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000  Network Applied Communication Laboratory, Inc.

--- a/string.c
+++ b/string.c
@@ -3,6 +3,7 @@
  *
  * This file is covered by the Ruby license. See COPYING for more details.
  *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000 Network Applied Communication Laboratory, Inc.

--- a/struct.c
+++ b/struct.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/symbol.c
+++ b/symbol.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby Symbols.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2010-2011, Apple Inc. All rights reserved.
  */
 

--- a/symbol.h
+++ b/symbol.h
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby Symbols.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2010-2011, Apple Inc. All rights reserved.
  */
 

--- a/thread.c
+++ b/thread.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby implementation of Thread.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2009-2011, Apple Inc. All rights reserved.
  * Copyright (C) 2004-2007 Koichi Sasada
  */

--- a/time.c
+++ b/time.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby implementation of Ruby 1.9's time.c
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/transcode.c
+++ b/transcode.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby implementation of transcode.c.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000 Network Applied Communication Laboratory, Inc.

--- a/ucnv.c
+++ b/ucnv.c
@@ -1,8 +1,9 @@
-/* 
+/*
  * MacRuby implementation of Ruby 1.9 String.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000 Network Applied Communication Laboratory, Inc.

--- a/variable.c
+++ b/variable.c
@@ -1,6 +1,7 @@
 /* 
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000  Network Applied Communication Laboratory, Inc.

--- a/version.c
+++ b/version.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */

--- a/version.h
+++ b/version.h
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  */
@@ -31,8 +32,8 @@ RUBY_EXTERN const char ruby_description[];
 RUBY_EXTERN const char ruby_copyright[];
 #endif
 
-#define RUBY_AUTHOR 		"Apple Inc."
-#define RUBY_BIRTH_YEAR 	2007
+#define RUBY_AUTHOR 		"The MacRuby Team"
+#define RUBY_BIRTH_YEAR 	2012
 
 #ifndef RUBY_REVISION
 # define RUBY_REVISION 0

--- a/vm.cpp
+++ b/vm.cpp
@@ -2,7 +2,8 @@
  * MacRuby VM.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2008-2011, Apple Inc. All rights reserved.
  */
 

--- a/vm.h
+++ b/vm.h
@@ -2,7 +2,8 @@
  * MacRuby VM.
  *
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2008-2011, Apple Inc. All rights reserved.
  */
 

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000  Network Applied Communication Laboratory, Inc.

--- a/vm_method.c
+++ b/vm_method.c
@@ -1,6 +1,7 @@
 /*
  * This file is covered by the Ruby license. See COPYING for more details.
- * 
+ *
+ * Copyright (C) 2012, The MacRuby Team. All rights reserved.
  * Copyright (C) 2007-2011, Apple Inc. All rights reserved.
  * Copyright (C) 1993-2007 Yukihiro Matsumoto
  * Copyright (C) 2000  Network Applied Communication Laboratory, Inc.
@@ -756,4 +757,3 @@ Init_eval_method(void)
     undefined = rb_intern("method_undefined");
     singleton_undefined = rb_intern("singleton_method_undefined");
 }
-


### PR DESCRIPTION
- Add new copyright strings for 2012 with the name set to The MacRuby Team
- Change the `RUBY_COPYRIGHT` constant to The MacRuby Team and reset the birth year to 2012

I skipped adding a new copyright to a few files that also had an Apple copyright:
- `markgc.c`
- `auto_zone_1060.h`
- files in the `icu-1060` directory
- the `.pmdoc` files to generate the installer (this was just an oversight on my part)

I'm also not sure if "Apple" should be changed to "The MacRuby Team" in places like https://github.com/MacRuby/MacRuby/blob/master/bs.c#L12 which also appears in `gc-stub.m`. Let me know and I'll make the changes right away.

I also have not updated the `update_copyrights` script yet.
