### PR TITLE
Encode to binary before writing with OpenSSL::SSL::SSLSocket

### DIFF
--- a/ext/openssl/lib/openssl/buffering.rb
+++ b/ext/openssl/lib/openssl/buffering.rb
@@ -248,7 +248,7 @@ module Buffering
 
   def write(s)
     do_write(s)
-    s.length
+    s.bytesize
   end
 
   # Writes _str_ in the non-blocking manner.

--- a/ext/openssl/lib/openssl/buffering.rb
+++ b/ext/openssl/lib/openssl/buffering.rb
@@ -115,7 +115,7 @@ module Buffering
   # underlying IO is writable.
   #
   # So OpenSSL::Buffering#read_nonblock needs two rescue clause as follows.
-  # 
+  #
   #  # emulates blocking read (readpartial).
   #  begin
   #    result = ssl.read_nonblock(maxlen)
@@ -225,6 +225,7 @@ module Buffering
   def do_write(s)
     @wbuffer = "" unless defined? @wbuffer
     @wbuffer << s
+    @wbuffer.force_encoding(Encoding::BINARY)
     @sync ||= false
     if @sync or @wbuffer.size > BLOCK_SIZE or idx = @wbuffer.rindex($/)
       remain = idx ? idx + $/.size : @wbuffer.length
@@ -270,7 +271,7 @@ module Buffering
   # underlying IO is writable.
   #
   # So OpenSSL::Buffering#write_nonblock needs two rescue clause as follows.
-  # 
+  #
   #  # emulates blocking write.
   #  begin
   #    result = ssl.write_nonblock(str)

--- a/test-mri/test/openssl/test_buffering.rb
+++ b/test-mri/test/openssl/test_buffering.rb
@@ -63,4 +63,10 @@ class OpenSSL::TestBuffering < MiniTest::Unit::TestCase
     refute @io.sync, 'sync must not change'
   end
 
+  def test_print
+    str = "123\r\n".force_encoding(Encoding::UTF_8)
+    @io.print(str)
+    assert(Encoding::BINARY, @io.string.encoding)
+  end
+
 end if defined?(OpenSSL)

--- a/test-mri/test/openssl/test_ssl.rb
+++ b/test-mri/test/openssl/test_ssl.rb
@@ -685,6 +685,36 @@ __EOS__
       ssl.close
     }
   end
+
+  def test_multibyte_read_write
+    #German a umlaut
+    auml = [%w{ C3 A4 }.join('')].pack('H*')
+    auml.force_encoding(Encoding::UTF_8)
+
+    str = nil
+    num_written = nil
+
+    server_proc = Proc.new {|ctx, ssl|
+      cmp = ssl.read
+      raw_size = cmp.size
+      cmp.force_encoding(Encoding::UTF_8)
+      assert_equal(str, cmp)
+      assert_equal(num_written, raw_size)
+      ssl.close
+    }
+
+    start_server(PORT, OpenSSL::SSL::VERIFY_NONE, true, :server_proc => server_proc){|server, port|
+      [10, 1000, 100000].each {|i|
+        sock = TCPSocket.new("127.0.0.1", port)
+        ssl = OpenSSL::SSL::SSLSocket.new(sock)
+        ssl.sync_close = true
+        ssl.connect
+        str = auml * i
+        num_written = ssl.write(str)
+        ssl.close
+      }
+    }
+  end
 end
 
 end


### PR DESCRIPTION
This PR should fix MacRuby/MacRuby#188. The problem is `Net::IMAP` sends  the content length in bytes to imap server, but `OpenSSL::SSL:SSLSocket#print` computes the content length in characters. That is why the patch sends the length in characters in the issue works.

The same fix in `OpenSSL::Buffering` is in MRI 1.9.3 or above.
